### PR TITLE
Bumped Jacoco version to 0.7.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
         <stanford-nlp.version>3.6.0.wso2v1</stanford-nlp.version>
         <testng.version>6.11</testng.version>
         <jollyday.version>0.4.7</jollyday.version>
-        <jacoco.plugin.version>0.7.8</jacoco.plugin.version>
+        <jacoco.plugin.version>0.7.9</jacoco.plugin.version>
     </properties>
 
     <scm>


### PR DESCRIPTION
## Purpose
Standardizing the version of Jacoco plugin used

## Approach
Bumped Jacoco version to 0.7.9

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes