### PR TITLE
Adding UTF-8 as default encoding

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,8 @@
         <testng.version>6.11</testng.version>
         <jollyday.version>0.4.7</jollyday.version>
         <jacoco.plugin.version>0.7.9</jacoco.plugin.version>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <scm>


### PR DESCRIPTION
## Purpose
Fix build due to encoding issue.

## Approach
Adding UTF-8 as encoding in properties

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes